### PR TITLE
[FEATURE] Ajouter un préfix dans le message de commit

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,5 +12,6 @@
   "prConcurrentLimit": 5,
   "rangeStrategy": "bump",
   "labels": ["dependencies"],
-  "stabilityDays": 7
+  "stabilityDays": 7,
+  "commitMessagePrefix": "[BUMP]"
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le format de commit fait par Renovate et utiliser comme titre de PR, ne passe pas la vérification faite par GitHub Action vérifiant le format de titre de PR (https://github.com/1024pix/pix/actions/workflows/check-pr-title.yaml) 

## :robot: Proposition
Ajouter un préfix correspondant à nos standards. 

## :rainbow: Remarques
Nous choisissons `[BUMP]` pour pouvoir facilement filtrer les PR de renovate

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
