### PR TITLE
[BUGFIX] Rendre visible le répertoire impacté par les PRs créées par Renovate 

### DIFF
--- a/presets/group-by-directory.json
+++ b/presets/group-by-directory.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "additionalBranchPrefix": "{{baseDir}}-",
-  "commitMessageSuffix": "{{#if baseDir}}({{baseDir}}){{/if}}"
+  "additionalBranchPrefix": "{{parentDir}}-",
+  "commitMessageSuffix": "{{#if parentDir}}({{parentDir}}){{/if}}"
 }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, Renovate groupe bien les PRs par répertoire, mais le nom du répertoire n'est pas visible dans le titre dans la PR malgré la configuration. 

Dans les logs de Renovate on peut voir que la variable n'est pas autorisé dans la configuration `commitMessageSuffix`
<img width="1467" alt="Screenshot 2023-02-16 at 15 20 43@2x" src="https://user-images.githubusercontent.com/26384707/219390243-c802d7f6-0924-4c4c-9508-d2f67b91fd28.png">

## :robot: Proposition
A la place, nous pouvons utiliser la variable `parentDir` qui corespond à la même chose et qui elle est autorisée : 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
J'ai testé pour vous sur un fork du repo Pix : 
<img width="693" alt="Screenshot 2023-02-16 at 15 17 21@2x" src="https://user-images.githubusercontent.com/26384707/219390554-f46f1b3e-8d3d-4e26-827d-d86d4cc7b8e7.png">