### PR TITLE
[FEATURE] Désactiver le rebase automatique des PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,5 +13,6 @@
   "rangeStrategy": "bump",
   "labels": ["dependencies"],
   "stabilityDays": 7,
-  "commitMessagePrefix": "[BUMP]"
+  "commitMessagePrefix": "[BUMP]",
+  "rebaseWhen": "never"
 }


### PR DESCRIPTION
## :unicorn: Problème
Le rebase automatique des PRs engendre le rate limit de l'API de GitHub.

## :robot: Proposition
Désactiver le rebase auto, il suffira de cocher la base rebase sur la PR pour le déclencher

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
