### PR TITLE
[FEATURE] Changer la strétégie pour du pinning de version.

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
     "local>1024pix/renovate-config//presets/group-by-directory"
   ],
   "prConcurrentLimit": 5,
-  "rangeStrategy": "bump",
+  "rangeStrategy": "pin",
   "labels": ["dependencies"],
   "stabilityDays": 7,
   "commitMessagePrefix": "[BUMP]",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque Renovate essaie de mettre à jour le package-lock, cela entraine la mise à jour de librairie qui cause fréquemment des régressions (tests qui ne passent plus).

## :robot: Proposition
Passer en pinning de version, ce qui permet lors de la mise à jour de package-lock de ne plus avoir de montée de version même mineure, ce qui on espère permettra de ne pas causer de régression.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
