### PR TITLE
:sparkles: Rassembler les propositions de mises à jour de dépendances globales

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,14 +5,15 @@
     ":maintainLockFilesMonthly",
     ":preserveSemverRanges",
     ":semanticCommits",
-    "schedule:earlyMondays",
     "local>1024pix/renovate-config//presets/group-dependencies-non-major",
-    "local>1024pix/renovate-config//presets/group-by-directory"
+    "local>1024pix/renovate-config//presets/group-by-directory",
+    "local>1024pix/renovate-config//presets/group-global-dependencies"
   ],
   "prConcurrentLimit": 5,
   "rangeStrategy": "pin",
   "labels": ["dependencies"],
   "stabilityDays": 7,
   "commitMessagePrefix": "[BUMP]",
-  "rebaseWhen": "never"
+  "rebaseWhen": "never",
+  "schedule": "every 1 hour every weekday"
 }

--- a/presets/group-by-directory.json
+++ b/presets/group-by-directory.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "additionalBranchPrefix": "{{parentDir}}-",
-  "commitMessageSuffix": "{{#if parentDir}}({{parentDir}}){{/if}}"
+  "packageRules": [
+    {
+      "excludePackagePatterns": ["(node|npm|eslint|nginx|redis|postgres)"],
+      "additionalBranchPrefix": "{{#if parentDir}}{{parentDir}}{{else}}dossier-racine{{/if}}-",
+      "commitMessageSuffix": "{{#if parentDir}}({{parentDir}}){{else}}(dossier racine){{/if}}"
+    }
+  ]
 }

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["(node|npm)"],
+      "groupName": "node"
+    },
+    {
+      "matchPackagePatterns": ["eslint"],
+      "groupName": "eslint"
+    },
+    {
+      "matchPackagePatterns": ["nginx"],
+      "groupName": "nginx"
+    },
+    {
+      "matchPackagePatterns": ["redis"],
+      "groupName": "redis"
+    },
+    {
+      "matchPackagePatterns": ["postgres"],
+      "groupName": "postgres"
+    }
+  ]
+}


### PR DESCRIPTION
## :unicorn: Problème
Les propositions de mises à jour de dépendances globales (ex: node,npm, pg) ouvrent une PR par dépendance et par contexte sur le monorepo Pix.

Hors, pour ces paquets, les versions ne peuvent pas être désynchronisées, notamment en raison de la CI.

## :robot: Proposition
Rassembler les propositions de mises à jour en une seule PR

## :rainbow: Remarques
J'ai également activé le passage de renovate toutes les heures des jours ouvrés, afin que nous ayons constamment 5 PR ouvertes par renovate, pour faire descendre plus rapidement le nombre de dépendances en retard

## :100: Pour tester
CF le dashboard du  projet forké du monorepo Pix sur lequel j'ai fait tout mes tests :
https://github.com/1024pix/pix-renovate-test/issues/4 
