### PR TITLE
[TECH] :wrench: Configurer les labels et la planification de Renovate pour les configurations personnalisées

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,23 @@ To help developers maintain dependencies up-to-date, we use Renovate with a shar
 Dependencies update can be monitored on the dashboard
 https://app.renovatebot.com/dashboard#github/1024pix/renovate-config/
 
-## Setup
+## Available configurations
 
-Choose your `preset` :
+Two `presets` are available :
 
 - `default`:
-  - wait 7 days after a version is published on npm to select it;
   - runs hourly every weekday;
+  - wait 7 days after a version is published on npm to select it;
   - create at most 5 pull request per week;
   - do not merge.
 - `aggressive`:
-  - runs several times per day;
+  - runs hourly every weekday;
   - create as many pull request as necessary;
-  - merge if tests pass (do not wait for review).
+  - approves its own PR using Github App Renovate Approve;
+  - adds label ":rocket: Ready to Merge" to the PR;
+  - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
+
+## Project onboarding
 
 Create a `renovate.json` file under `.github` folder.
 
@@ -33,7 +37,18 @@ Create a `renovate.json` file under `.github` folder.
 
 Substitute your preset, eg. `github>1024pix/renovate-config:default`.
 
-Ask an organization Github administrator to activate Renovate application on the repository.
+Ask a Github organization administrator to activate the application [Renovate][renovate] on the repository.
 
-Check the logs to make sure it starts for the first time, even if it does not detect any outdated dependency.
+> Automerge functionnality also requires the application [Renovate Approve][renovate-approve] to be enabled on the repository.
+
+Check the execution logs to make sure it starts for the first time, even if it does not detect any outdated dependency.
 Eg. for `pix-bot` repository https://app.renovatebot.com/dashboard#github/1024pix/pix-bot
+
+### Onboarding forked projects
+
+If the project is a fork, you need to add the following configuration in the `renovate.json` file : `"includeForks": true`
+
+Issues are disabled by default on forked projects, Dependency dashboard needs Github Issues to appear.
+
+[renovate]: https://github.com/apps/renovate/installations/new
+[renovate-approve]: https://github.com/apps/renovate-approve/installations/new

--- a/aggressive.json
+++ b/aggressive.json
@@ -1,14 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>1024pix/renovate-config:default"],
-  "schedule": ["at any time"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "labels": ["renovate", "no-review-app"],
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["*"],
-      "automerge": true
-    }
-  ]
+  "addLabels": ["aggressive", ":rocket: Ready to Merge"],
+  "automerge": true
 }

--- a/default.json
+++ b/default.json
@@ -10,9 +10,8 @@
     "local>1024pix/renovate-config//presets/group-global-dependencies"
   ],
   "prConcurrentLimit": 5,
-  "rangeStrategy": "pin",
   "labels": ["dependencies"],
-  "stabilityDays": 7,
+  "minimumReleaseAge": "7 days",
   "commitMessagePrefix": "[BUMP]",
   "rebaseWhen": "never",
   "schedule": "every 1 hour every weekday"


### PR DESCRIPTION
## :unicorn: Problème

La configuration n'est pas cohérente au niveau des labels sur les configurations personnalisées.

## :robot: Proposition

Mise en place de labels de base et de labels supplémentaires pour la configuration agressive

## :rainbow: Remarques

Ajout de documentation pour spécifier le fonctionnement de chacune des configurations, et la procédure d'onboarding

## :100: Pour tester

Merger et suivre le comportement sur les projets onboardés 
