### PR TITLE
[BUGFIX] Le preset `confident` nécessite paiement à Renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Three `presets` are available :
   - wait 7 days after a version is published on npm to select it;
   - create at most 5 pull request per week;
   - do not merge.
-- `confident`:
+- `auto-patch`:
   - runs hourly every weekday;
   - wait 7 days after a version is published on npm to select it;
   - create at most 5 pull request per week;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Three `presets` are available :
   - wait 7 days after a version is published on npm to select it;
   - create at most 5 pull request per week;
   - approves its own PR using Github App Renovate Approve;
-  - adds label ":rocket: Ready to Merge" to the PR if [Renovate's confidence](https://docs.renovatebot.com/merge-confidence/) is "high" or "very high";
+  - adds label ":rocket: Ready to Merge" to the PR if update type is a patch;
   - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
 - `aggressive`:
   - runs hourly every weekday;

--- a/auto-patch.json
+++ b/auto-patch.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
-      "addLabels": ["confident", ":rocket: Ready to Merge"],
+      "addLabels": ["auto-patch", ":rocket: Ready to Merge"],
       "automerge": true
     }
   ]

--- a/confident.json
+++ b/confident.json
@@ -3,7 +3,7 @@
   "extends": ["github>1024pix/renovate-config:default"],
   "packageRules": [
     {
-      "matchConfidence": ["high", "very high"],
+      "matchUpdateTypes": ["patch"],
       "addLabels": ["confident", ":rocket: Ready to Merge"],
       "automerge": true
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "run-p validate:**",
     "validate:default": "renovate-config-validator default.json",
     "validate:aggressive": "renovate-config-validator aggressive.json",
-    "validate:confident": "renovate-config-validator confident.json",
+    "validate:auto-patch": "renovate-config-validator auto-patch.json",
     "validate:presets": "renovate-config-validator presets/*.json"
   },
   "repository": {


### PR DESCRIPTION
## :unicorn: Problème
La config pour le preset `confident` introduit avec #14 nécessite un abonnement chez Mend.

## :robot: Proposition
Retirer le `matchConfidence` :'( pour le remplacer par une détection des patchs.

## :rainbow: Remarques
RAS

## :100: Pour tester
Revérifier après merge que cette nouvelle config est gratuite.