### PR TITLE
[TECH] :wrench: Rechercher les paquets exacts au lieu de tous ceux comprenant le nom de paquet 

### DIFF
--- a/presets/group-by-directory.json
+++ b/presets/group-by-directory.json
@@ -2,7 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "excludePackagePatterns": ["(node|npm|eslint|nginx|redis|postgres)"],
+      "excludePackagePatterns": [
+        "^(node|npm|cimg/node|eslint|nginx|redis|postgres)$"
+      ],
       "additionalBranchPrefix": "{{#if parentDir}}{{parentDir}}{{else}}dossier-racine{{/if}}-",
       "commitMessageSuffix": "{{#if parentDir}}({{parentDir}}){{else}}(dossier racine){{/if}}"
     }

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -2,25 +2,42 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchPackagePatterns": ["(node|npm)"],
-      "excludeDepNames": "nodemon",
+      "matchPackagePatterns": ["^(node|npm|cimg/node)$"],
       "groupName": "node",
       "rangeStrategy": "bump"
     },
     {
-      "matchPackagePatterns": ["eslint"],
+      "matchPackagePatterns": ["^eslint$"],
       "groupName": "eslint"
     },
     {
-      "matchPackagePatterns": ["nginx"],
+      "matchPackagePatterns": ["^nginx$"],
+      "matchManagers": [
+        "circleci",
+        "docker-compose",
+        "dockerfile",
+        "github-actions"
+      ],
       "groupName": "nginx"
     },
     {
-      "matchPackagePatterns": ["redis"],
+      "matchPackagePatterns": ["^redis$"],
+      "matchManagers": [
+        "circleci",
+        "docker-compose",
+        "dockerfile",
+        "github-actions"
+      ],
       "groupName": "redis"
     },
     {
-      "matchPackagePatterns": ["postgres"],
+      "matchPackagePatterns": ["^postgres$"],
+      "matchManagers": [
+        "circleci",
+        "docker-compose",
+        "dockerfile",
+        "github-actions"
+      ],
       "groupName": "postgres"
     }
   ]


### PR DESCRIPTION
## :unicorn: Problème

Renovate regroupe actuellement des mises à jour de paquets en utilisant une regex qui matche tous les paquets dont le nom contient ce que l'on cherche.
ex : Pour node, on regroupe les mises à jour de node et de nodemon

## :robot: Proposition

Faire un match exact du paquet, et du gestionnaire auquel on s'attend lors du regroupement


## :100: Pour tester

🟢  et surveiller les PR créées après le merge 
