### PR TITLE
[TECH] Ne pas proposer les versions majeures de Node et npm

### DIFF
--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -3,11 +3,13 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["^npm$"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "npm",
       "rangeStrategy": "bump"
     },
     {
       "matchPackagePatterns": ["^(node|cimg/node)$"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "node",
       "rangeStrategy": "bump"
     },

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -4,20 +4,17 @@
     {
       "matchPackagePatterns": ["^npm$"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm",
-      "rangeStrategy": "bump"
+      "groupName": "npm"
     },
     {
       "matchPackagePatterns": ["^(node|cimg/node)$"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "node",
-      "rangeStrategy": "bump"
+      "groupName": "node"
     },
     {
       "matchPackagePatterns": ["^(node|npm|cimg/node)$"],
       "matchUpdateTypes": ["major"],
-      "groupName": "node-npm",
-      "rangeStrategy": "bump",
+      "groupName": "node-npm"
       "enabled": false
     },
     {

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -14,6 +14,13 @@
       "rangeStrategy": "bump"
     },
     {
+      "matchPackagePatterns": ["^(node|npm|cimg/node)$"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "node-npm",
+      "rangeStrategy": "bump",
+      "enabled": false
+    },
+    {
       "matchPackagePatterns": ["^eslint$"],
       "groupName": "eslint"
     },

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -14,7 +14,7 @@
     {
       "matchPackagePatterns": ["^(node|npm|cimg/node)$"],
       "matchUpdateTypes": ["major"],
-      "groupName": "node-npm"
+      "groupName": "node-npm",
       "enabled": false
     },
     {


### PR DESCRIPTION
## :unicorn: Problème
Renovate propose aujourd'hui les mises à jour de version majeures de Node et npm.

## :robot: Proposition
Garder le contrôle sur les montées de version majeures en les faisant manuellement.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les bump major ne sont pas proposés sur pix-renovate-test.
