### PR TITLE
[TECH] Nettoyage du preset de regroupement

### DIFF
--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchPackagePatterns": ["^(node|cimg/node)$"],
+      "matchPackagePatterns": ["^node$"],
       "groupName": "node",
       "rangeStrategy": "bump"
     },

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -4,7 +4,8 @@
     {
       "matchPackagePatterns": ["^node$"],
       "groupName": "node",
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "versioning": "node"
     },
     {
       "matchPackagePatterns": ["^eslint$"],

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -2,11 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchPackagePatterns": ["^npm$"],
-      "groupName": "npm",
-      "rangeStrategy": "bump"
-    },
-    {
       "matchPackagePatterns": ["^(node|cimg/node)$"],
       "groupName": "node",
       "rangeStrategy": "bump"


### PR DESCRIPTION
## :unicorn: Problème
- On regroupe les montées de version de npm qui n'ont pas besoin d'être spécifiées.
- On essaye de regrouper les montées de version de node et cimg/node, cela ne gère pas les images custom de CircleCI `v16.17.0-browsers`.

## :robot: Proposition
- Avec https://github.com/1024pix/pix/pull/6698 on ne devrait plus en avoir besoin.
- Avec https://github.com/1024pix/renovate-config/pull/24, on gère différemment.

## :rainbow: Remarques
RAS

## :100: Pour tester
Testé sur [pix-renovate-test](https://github.com/1024pix/pix-renovate-test/)
