### PR TITLE
[TECH] Grouper les mises à jour des images CircleCI node avec les versions de node

### DIFF
--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchPackagePatterns": ["^node$"],
+      "matchPackagePatterns": ["^(node|cimg/node)$"],
       "groupName": "node",
       "rangeStrategy": "bump",
       "versioning": "node"


### PR DESCRIPTION
## :unicorn: Problème

Suite à la découverte d'un problème sur le versioning node qui retirait le suffixe `-browsers` des versions d'image docker de node dans circleci, le regroupement de ces mises à jour a été désactivé

## :robot: Proposition

Réactiver le groupage de ces mises à jour et le versioning node maintenant que tous les projets utilisant une image `-browsers` ont été migrés.

## :100: Pour tester

Renovate devra proposer des PR de Maj de node sur les images cimg/node avec la même version que dans le reste des fichiers