### PR TITLE
[FEATURE] Ajoute des groupes de dépendances

### DIFF
--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -8,8 +8,28 @@
       "versioning": "node"
     },
     {
+      "matchPackagePatterns": ["^@1024pix/pix-ui$"],
+      "groupName": "pix-ui"
+    },
+    {
+      "matchPackagePatterns": ["^@1024pix/ember-testing-library$"],
+      "groupName": "pix-ember-testing-library"
+    },
+    {
+      "matchPackagePatterns": ["^@1024pix/stylelint-config$"],
+      "groupName": "pix-stylelint-config"
+    },
+    {
+      "matchPackagePatterns": ["^@1024pix/eslint-config$"],
+      "groupName": "pix-eslint-config"
+    },
+    {
       "matchPackagePatterns": ["^eslint$"],
       "groupName": "eslint"
+    },
+    {
+      "matchPackagePatterns": ["^qunit$"],
+      "groupName": "qunit"
     },
     {
       "matchPackagePatterns": ["^nginx$"],

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -9,19 +9,23 @@
     },
     {
       "matchPackagePatterns": ["^@1024pix/pix-ui$"],
-      "groupName": "pix-ui"
+      "groupName": "pix-ui",
+      "minimumReleaseAge": "0"
     },
     {
       "matchPackagePatterns": ["^@1024pix/ember-testing-library$"],
-      "groupName": "pix-ember-testing-library"
+      "groupName": "pix-ember-testing-library",
+      "minimumReleaseAge": "0"
     },
     {
       "matchPackagePatterns": ["^@1024pix/stylelint-config$"],
-      "groupName": "pix-stylelint-config"
+      "groupName": "pix-stylelint-config",
+      "minimumReleaseAge": "0"
     },
     {
       "matchPackagePatterns": ["^@1024pix/eslint-config$"],
-      "groupName": "pix-eslint-config"
+      "groupName": "pix-eslint-config",
+      "minimumReleaseAge": "0"
     },
     {
       "matchPackagePatterns": ["^eslint$"],


### PR DESCRIPTION
Que Renovate propose les montées de version groupées pour toutes nos dépendances internes. Est-ce possible de ne pas atteindre 7j pour eux ?

Également ajout de `qunit` qu'on utilise dans tous nos fronts.