### PR TITLE
[FEATURE] Activer l'automerge de patchs/minor par défaut (PIX-9970)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ https://app.renovatebot.com/dashboard#github/1024pix/renovate-config/
 
 ## Available configurations
 
-Four `presets` are available :
+Here are the available `presets`:
 
 - `default`:
+  - runs hourly every weekday;
+  - wait 7 days after a version is published on npm to select it;
+  - create at most 5 pull request per week;
+  - approves its own PR using Github App Renovate Approve;
+  - adds label ":rocket: Ready to Merge" to the PR if update type is a minor or a patch;
+  - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
+- `no-auto`:
   - runs hourly every weekday;
   - wait 7 days after a version is published on npm to select it;
   - create at most 5 pull request per week;
@@ -23,13 +30,6 @@ Four `presets` are available :
   - approves its own PR using Github App Renovate Approve;
   - adds label ":rocket: Ready to Merge" to the PR if update type is a patch;
   - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
-- `auto-minor`:
-  - runs hourly every weekday;
-  - wait 7 days after a version is published on npm to select it;
-  - create at most 5 pull request per week;
-  - approves its own PR using Github App Renovate Approve;
-  - adds label ":rocket: Ready to Merge" to the PR if update type is a minor or a patch;
-  - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
 - `aggressive`:
   - runs hourly every weekday;
   - wait 7 days after a version is published on npm to select it;
@@ -37,6 +37,8 @@ Four `presets` are available :
   - approves its own PR using Github App Renovate Approve;
   - adds label ":rocket: Ready to Merge" to the PR;
   - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
+
+`auto-minor` is a deprecated config and should be replaced by the `default` config.
 
 ## Project onboarding
 

--- a/default.json
+++ b/default.json
@@ -15,5 +15,12 @@
   "minimumReleaseAge": "7 days",
   "commitMessagePrefix": "[BUMP]",
   "rebaseWhen": "never",
-  "schedule": "every 1 hour every weekday"
+  "schedule": "every 1 hour every weekday",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "minor"],
+      "addLabels": ["auto-minor", ":rocket: Ready to Merge"],
+      "automerge": true
+    }
+  ]
 }

--- a/no-auto.json
+++ b/no-auto.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":maintainLockFilesMonthly",
+    ":preserveSemverRanges",
+    ":semanticCommits",
+    ":separateMultipleMajorReleases",
+    "local>1024pix/renovate-config//presets/detect-circleci-custom-dependencies",
+    "local>1024pix/renovate-config//presets/group-by-directory",
+    "local>1024pix/renovate-config//presets/group-global-dependencies"
+  ],
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "7 days",
+  "commitMessagePrefix": "[BUMP]",
+  "rebaseWhen": "never",
+  "schedule": "every 1 hour every weekday"
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "prettier --check .",
     "test": "run-p validate:**",
     "validate:default": "renovate-config-validator default.json",
+    "validate:no-auto": "renovate-config-validator no-auto.json",
     "validate:aggressive": "renovate-config-validator aggressive.json",
     "validate:auto-patch": "renovate-config-validator auto-patch.json",
     "validate:auto-minor": "renovate-config-validator auto-minor.json",


### PR DESCRIPTION
## :unicorn: Problème
On a du mal à suivre les montées de versions de nos nombreuses dépendances. En résulte [un drift](https://1024pix.github.io/dependency-drift-tracker/) relativement important et des potentiels risques de sécurités.

## :robot: Proposition
Activer les montées de versions automatiques dans le cas où la montée de version est de type minor ou patch et que la CI est verte.

Cela résultera en des montées de version plus régulières. Potentiellement quelques bugs pourront apparaître si notre code est mal couvert par nos tests. Il conviendra d'ajuster les tests si on se rend compte de ce genre de bugs.

## :rainbow: Remarques
RAS

## :100: Pour tester
?
