### PR TITLE
[FEATURE] Revoir la stratégie de merge des dépendances @1024pix (PIX-9553)

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,6 +16,7 @@
   "commitMessagePrefix": "[BUMP]",
   "rebaseWhen": "never",
   "schedule": "every 1 hour every weekday",
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor"],

--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":maintainLockFilesMonthly",
+    ":maintainLockFilesWeekly",
     ":preserveSemverRanges",
     ":semanticCommits",
     ":separateMultipleMajorReleases",

--- a/default.json
+++ b/default.json
@@ -20,7 +20,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor"],
-      "addLabels": ["auto-minor", ":rocket: Ready to Merge"],
+      "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
       "automerge": true
     }
   ]

--- a/default.json
+++ b/default.json
@@ -18,13 +18,7 @@
   "schedule": "every 1 hour every weekday",
   "packageRules": [
     {
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
-      "automerge": true
-    },
-    {
-      "matchPackagePatterns": ["^@1024pix/"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["lockFileMaintenance", "minor", "patch"],
       "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
       "automerge": true
     }

--- a/default.json
+++ b/default.json
@@ -16,10 +16,9 @@
   "commitMessagePrefix": "[BUMP]",
   "rebaseWhen": "never",
   "schedule": "every 1 hour every weekday",
-  "rangeStrategy": "pin",
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
       "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
       "automerge": true
     }

--- a/default.json
+++ b/default.json
@@ -21,6 +21,12 @@
       "matchUpdateTypes": ["lockFileMaintenance"],
       "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^@1024pix/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
+      "automerge": true
     }
   ]
 }

--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -8,24 +8,25 @@
       "versioning": "node"
     },
     {
+      "matchPackagePatterns": ["^@1024pix/"],
+      "minimumReleaseAge": "0",
+      "rangeStrategy": "bump"
+    },
+    {
       "matchPackagePatterns": ["^@1024pix/pix-ui$"],
-      "groupName": "pix-ui",
-      "minimumReleaseAge": "0"
+      "groupName": "pix-ui"
     },
     {
       "matchPackagePatterns": ["^@1024pix/ember-testing-library$"],
-      "groupName": "pix-ember-testing-library",
-      "minimumReleaseAge": "0"
+      "groupName": "pix-ember-testing-library"
     },
     {
       "matchPackagePatterns": ["^@1024pix/stylelint-config$"],
-      "groupName": "pix-stylelint-config",
-      "minimumReleaseAge": "0"
+      "groupName": "pix-stylelint-config"
     },
     {
       "matchPackagePatterns": ["^@1024pix/eslint-config$"],
-      "groupName": "pix-eslint-config",
-      "minimumReleaseAge": "0"
+      "groupName": "pix-eslint-config"
     },
     {
       "matchPackagePatterns": ["^eslint$"],


### PR DESCRIPTION
## :unicorn: Problème
Les PRs `@1024pix` ne semblent plus ouvertes depuis la dernière mise à jour de notre config renovate.

Il semblerait que nos configs ne s'appliquent pas car elles sont regroupées dans les lockfile maintenances. Voir : https://github.com/1024pix/pix/pull/7545.

## :robot: Proposition
Séparer les montées de version des dépendances `@1024pix` du lockfile maintenance pour accélérer leur release schedule : celui par défaut du `default.json` (toutes les heures pendant les jours ouvrés). On devrait pouvoir ainsi s'éviter des actions manuelles pour monter de version pix-ui et autres...

Automerger :
- les lockfile maintenance,
- les minor et patch (node, 1024pix...)

## :rainbow: Remarques
Je propose aussi de renommer le label ajouté aux PR en `auto-bump` pour ne pas confondre avec `auto-minor` et `auto-patch`.

## :100: Pour tester
Vérifier que la CI passe.

En local lancer
```
docker run -it -v $PWD:/usr/src/app/ -e LOG_LEVEL=debug -e RENOVATE_CONFIG_FILE=default.json -e RENOVATE_DRY_RUN="full" -e RENOVATE_TOKEN="xxxxx" renovate/renovate 1024pix/pix
```
avec `RENOVATE_TOKEN` qui contient un [PAT GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) limité en lecture.