### PR TITLE
[BUGFIX] Eviter les automerges autres que `1024pix`, `node` et `lockfile maintenance` (PIX-9553)

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,7 +18,13 @@
   "schedule": "every 1 hour every weekday",
   "packageRules": [
     {
-      "matchUpdateTypes": ["lockFileMaintenance", "minor", "patch"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^@1024pix/", "^(node|cimg/node)$"],
+      "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
       "automerge": true
     }


### PR DESCRIPTION
## :christmas_tree: Problème
Notre stratégie de "pin" pour éviter les bumps auto ne fonctionne plus en l'état.

Toutes les applis ont par exemple [bump `@fortawesome/fontawesome-svg-core` qui était pinned](https://github.com/1024pix/pix/pull/7621).

(Dans ce cas ci on s'en fiche un peu car c'était [une erreur dans le package.json qu'on a corrigé](https://github.com/1024pix/pix/pull/7624))

Mais pour les deps qu'on a "pin" volontairement pour éviter les mises à jour auto on risque de péter un truc (voir la section "ignored or blocked" dans [le dependency tracker](https://github.com/1024pix/pix/issues/5637))

## :gift: Proposition
Rendre plus strict notre matching pour l'automerge, donc plus précisement : 
- matcher les dépendances `@1024pix` mineures et patchs
- matcher les bumps de `node` mineures et patchs
- (on continue de matcher les lockfile maintenance)

## :socks: Remarques
RAS

## :santa: Pour tester

