### PR TITLE
[TECH] Fixer la version des images postgres et redis avec la versions des addons Scalingo (PIX-9281).

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,11 @@
     ":separateMultipleMajorReleases",
     "local>1024pix/renovate-config//presets/detect-circleci-custom-dependencies",
     "local>1024pix/renovate-config//presets/group-by-directory",
-    "local>1024pix/renovate-config//presets/group-global-dependencies"
+    "local>1024pix/renovate-config//presets/group-global-dependencies",
+    "local>1024pix/renovate-config//presets/scalingo-addon-datasources",
+    "local>1024pix/renovate-config//presets/scalingo-postgres-custom-manager",
+    "local>1024pix/renovate-config//presets/scalingo-redis-custom-manager",
+    "local>1024pix/renovate-config//presets/disable-automerge-and-docker-datasource-for-postgres-and-redis"
   ],
   "prConcurrentLimit": 5,
   "labels": ["dependencies"],

--- a/presets/disable-automerge-and-docker-datasource-for-postgres-and-redis.json
+++ b/presets/disable-automerge-and-docker-datasource-for-postgres-and-redis.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchPackageNames": ["postgres", "redis"],
+      "matchDatasources": ["docker"],
+      "enabled": false
+    },
+    {
+      "matchDepTypes": ["postgres", "redis"],
+      "matchDatasources": ["scalingo-postgres", "scalingo-redis"],
+      "automerge": false
+    }
+  ]
+}

--- a/presets/scalingo-addon-datasources.json
+++ b/presets/scalingo-addon-datasources.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customDatasources": {
+    "scalingo-redis": {
+      "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/scalingo/repositories/redis/tags",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": $map($$.results, function($v) { { \"version\": $substringBefore($v.name, '-') } })}"
+      ]
+    },
+    "scalingo-postgres": {
+      "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/scalingo/repositories/postgresql/tags",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": $map($$.results, function($v) { { \"version\": $split($v.name, '.', 2) ~> $join('.') } })}"
+      ]
+    }
+  }
+}

--- a/presets/scalingo-postgres-custom-manager.json
+++ b/presets/scalingo-postgres-custom-manager.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^scalingo.json$",
+        "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "\"plan\": \"postgresql:postgresql-sandbox\",\\s*.*\\s.*\"version\": \"(?<currentValue>.*)\"",
+        "postgres:\\s.*image: postgres:(?<currentValue>.*)-alpine"
+      ],
+      "depNameTemplate": "postgres",
+      "datasourceTemplate": "custom.scalingo-postgres"
+    }
+  ]
+}

--- a/presets/scalingo-redis-custom-manager.json
+++ b/presets/scalingo-redis-custom-manager.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^scalingo.json$",
+        "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "\"plan\": \"redis:redis-sandbox\",\\s*.*\\s.*\"version\": \"(?<currentValue>.*)\"",
+        "redis:\\s.*image: redis:(?<currentValue>.*)-alpine"
+      ],
+      "depNameTemplate": "redis",
+      "datasourceTemplate": "custom.scalingo-redis"
+    }
+  ]
+}


### PR DESCRIPTION
## :christmas_tree: Problème
Aujourd'hui, Renovate nous permet de mettre à jour nos dépendances applicatives ainsi que la version des images postgres et redis dans nos fichiers docker-compose. Cependant, les versions proposées par Renovate ne sont pas forcément en adéquation avec les versions des addons proposés par Scalingo.  

## :gift: Proposition
- Ajouter deux nouvelles datasources `scalingo-postgres` et `scalingo-redis` permettant de récupérer les versions des addons disponibles chez Scalingo.
- Ajouter un custom manager permettant de récupérer les versions des images postgres et redis dans tous nos fichier `docker-compse` (à l'image de ce qui existe pour le fichier de configuration de CircleCI).
- Ajouter deux custom managers permettant de récupérer les versions des images postgres et redis dans le fichier scalingo.json
- Désactiver la datasource docker pour les dépendances postgres et redis afin que Renovate ne nous propose pas d'autres versions que celles issues des datasources Scalingo.  

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Voir le projet pix-renovate-test pour lequel les configurations précédentes ont été ajoutées.
