### PR TITLE
[TECH] Inclure le fichier de configuration de circleci dans les configurations postgres et redis (PIX-9281).

### DIFF
--- a/presets/scalingo-postgres-custom-manager.json
+++ b/presets/scalingo-postgres-custom-manager.json
@@ -5,11 +5,12 @@
       "customType": "regex",
       "fileMatch": [
         "^scalingo.json$",
-        "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$"
+        "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$",
+        "^.circleci/config.yml$"
       ],
       "matchStrings": [
         "\"plan\": \"postgresql:postgresql-sandbox\",\\s*.*\\s.*\"version\": \"(?<currentValue>.*)\"",
-        "postgres:\\s.*image: postgres:(?<currentValue>.*)-alpine"
+        "image: postgres:(?<currentValue>.*)-alpine"
       ],
       "depNameTemplate": "postgres",
       "datasourceTemplate": "custom.scalingo-postgres"

--- a/presets/scalingo-redis-custom-manager.json
+++ b/presets/scalingo-redis-custom-manager.json
@@ -5,11 +5,12 @@
       "customType": "regex",
       "fileMatch": [
         "^scalingo.json$",
-        "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$"
+        "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$",
+        "^.circleci/config.yml$"
       ],
       "matchStrings": [
         "\"plan\": \"redis:redis-sandbox\",\\s*.*\\s.*\"version\": \"(?<currentValue>.*)\"",
-        "redis:\\s.*image: redis:(?<currentValue>.*)-alpine"
+        "image: redis:(?<currentValue>.*)-alpine"
       ],
       "depNameTemplate": "redis",
       "datasourceTemplate": "custom.scalingo-redis"


### PR DESCRIPTION
## :christmas_tree: Problème
Une configuration particulière existe afin de gérer les images dans le fichier de configuration circleci grâce à des commentaires. Cette technique est la seule solution pour les images node mais n'est pas obligatoire pour postgres et redis. A la place, on peut utiliser la configuration existante pour les fichiers docker-compose et scalingo.json en modifiant légèrement une des expression régulière 

## :gift: Proposition
- Inclure le fichier de configuration de circleci dans scalingo-postgres-custom-manager.json
- Inclure le fichier de configuration de circleci dans scalingo-redis-custom-manager.json