### PR TITLE
[TECH] :sparkles: Ajouter des identifiants de connexion pour hub.docker

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,7 @@
     ":preserveSemverRanges",
     ":semanticCommits",
     ":separateMultipleMajorReleases",
+    "local>1024pix/renovate-config//presets/docker-auth",
     "local>1024pix/renovate-config//presets/detect-circleci-custom-dependencies",
     "local>1024pix/renovate-config//presets/group-by-directory",
     "local>1024pix/renovate-config//presets/group-global-dependencies",

--- a/presets/docker-auth.json
+++ b/presets/docker-auth.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "hostRules": [
+    {
+      "matchHost": "https://hub.docker.com",
+      "username": "pixdockerhub",
+      "encrypted": {
+        "password": "wcFMA/xDdHCJBTolAQ/+KRr0tWytYIylmc28Oa8fmzTa2HrzDKvbiECpSZiZ78qp0mm4+g3YOwVAc7JEFe+ygxE9f8Y4MHvKNsxrxIOtseu+pmkP3hL1CU3S2ZZIFNOu9gcAiBAfoZisPnFbHvCWGaywUqQBm9PY+0/2xnxgLAkhxuAnzWsabHDGzC2cI65eVnNa6imMrXOCwEvYcm6I1CD5kM5JavdMKhdZpMB8IiLScTadKgNp2u1rQRe4nK8uIlbK0CPjqi57WpcazFkzaBA/ZVXqkhpextMERWFG+OelYA1hV0v0nus5kBFBtx1Gc9w4t+0oxo4eUdve40Gv1YTu0QCvwKsSxvaDFqryNv4Z5mOkIRJowLK6ifDeiUK0tDtokCwm5XR0/wd7qHU7LmZ/UII0Jyz9L9VOleAIPP4+J5bLv9saBoGn6Wco3dc5YaGW/S1X0tvrE/9wCgtG/YFcuHgQexhk0O+3LXjUrrPszS5L3e1zY8HSfokzfdLkfnphHc4Vf+rqgeBHt4vS3qnxJHEb6JG+aJnod4dMuQFcnSfwKidHpHu7O6f0KZB02fHHBFLd2dvKeMmI1jcDPtaBTAGZ0o7aLMSrI5Phn1mojv81xy4aY84u7OyZmK/RNdXoLOmU6yOPh2cqaO5IBR37sugOxBujZYRPYTnmRSKjMST3FedrJgSDJQOlVz/ScgGPxWLuEHnVgzykjJi7w9brzjZnl/DnEuqEX+0fh/eeva0K4CO4ENinyVxbMjy2AFON8XyGGmsH7nIP4eago4mHlGkCui7Q+qZkHTYT1jLZ7Nlcm9IpfL315L0uErqOZjc8RjUbK2YpgiEfi/g3yTFOCA"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## :christmas_tree: Problème

Les requêtes permettant de lister les versions disponibles de redis et postgres depuis le hub docker utilise un token général de Renovate, qui atteint le rate limit assez souvent 

## :gift: Proposition

Utiliser notre propre compte docker hub, et passer l'authentification en secret via la procédure https://docs.renovatebot.com/getting-started/private-packages/#encryption-and-the-mend-renovate-app utilisant https://app.renovatebot.com/encrypt

## :santa: Pour tester

Mis en place sur pix-renovate-test : https://github.com/1024pix/pix-renovate-test/commit/2ae62fdae384553a8c950d8a05f8aad58a379b5e
