### PR TITLE
[FEATURE] Ne pas grouper les montées de version d'ESLint

### DIFF
--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -25,7 +25,6 @@
       "matchPackageNames": ["/^@1024pix/eslint-config$/"],
       "groupName": "pix-eslint-config"
     },
-    { "matchPackageNames": ["/^eslint$/"], "groupName": "eslint" },
     { "matchPackageNames": ["/^sinon$/"], "groupName": "sinon" },
     { "matchPackageNames": ["/^qunit$/"], "groupName": "qunit" },
     {


### PR DESCRIPTION
## :unicorn: Problème
Les montées de version ESLint sont groupées quand la dépendance est présente dans plusieurs sous-dossiers (voir [par exemple pix-editor](https://github.com/1024pix/pix-editor/pull/667)). Pour la montée de version en v9 d'ESLint c'est un peu ambitieux car ça demande que tous les projets migrent en même temps

## :robot: Proposition
Désactiver cette règle, au moins le temps de monter en v9.

## :100: Pour tester
?
