### PR TITLE
[BUGFIX] Réparer le groupement par dossier pour la MAJ des lockfiles

### DIFF
--- a/presets/group-by-directory.json
+++ b/presets/group-by-directory.json
@@ -5,6 +5,11 @@
       "matchPackageNames": ["!/^(node|npm|cimg/node|nginx|redis|postgres)$/"],
       "additionalBranchPrefix": "{{#if parentDir}}{{parentDir}}{{else}}dossier-racine{{/if}}-",
       "commitMessageSuffix": "{{#if parentDir}}({{parentDir}}){{else}}(dossier racine){{/if}}"
+    },
+    {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "additionalBranchPrefix": "{{#if parentDir}}{{parentDir}}{{else}}dossier-racine{{/if}}-",
+      "commitMessageSuffix": "{{#if parentDir}}({{parentDir}}){{else}}(dossier racine){{/if}}"
     }
   ]
 }


### PR DESCRIPTION
## :fallen_leaf: Problème
Depuis la PR #83 il me semble, les lockfiles ne sont plus groupés par dossier. Ce qui fait que les PR MAJ de lockfiles sont très grosses sur le repo principale et ne passent pas.

## :chestnut: Proposition
Pour avoir des PR plus petites, rétablir le groupement par dossier

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
