### PR TITLE
[DOC] Mettre à jour la variable à activer pour un fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Eg. for `pix-bot` repository https://app.renovatebot.com/dashboard#github/1024pi
 
 ### Onboarding forked projects
 
-If the project is a fork, you need to add the following configuration in the `renovate.json` file : `"includeForks": true`
+If the project is a fork, you need to add the following configuration in the `renovate.json` file : `"forkProcessing": "enabled",`
 
 Issues are disabled by default on forked projects, Dependency dashboard needs Github Issues to appear.
 


### PR DESCRIPTION
## 🔆 Problème

La variable pour activer renovate sur un fork est désormais déprécié. 

## ⛱️ Proposition
Utiliser la nouvelle variable

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
