### PR TITLE
[FEATURE] Grouper certaines montées de version

### DIFF
--- a/presets/group-global-dependencies.json
+++ b/presets/group-global-dependencies.json
@@ -32,6 +32,14 @@
     },
     { "matchPackageNames": ["/^sinon$/"], "groupName": "sinon" },
     { "matchPackageNames": ["/^qunit$/"], "groupName": "qunit" },
+     {
+      "matchPackageNames": ["/^@embroider/"],
+      "groupName": "embroider"
+    },
+    {
+      "matchPackageNames": ["/eslint/"],
+      "groupName": "eslint"
+    },
     {
       "matchPackageNames": ["/^nginx$/"],
       "matchManagers": [


### PR DESCRIPTION
## 🔆 Problème

Actuellement, nous avons certaines désynchro, ou encore des dépendances qui sont mise à jour seule.

## ⛱️ Proposition

Grouper les packages contenant `eslint` et `@embroider`

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
