### PR TITLE
[FEATURE] Permettre la mise à jour des fichiers scalingo.json présents dans des sous dossiers

### DIFF
--- a/presets/scalingo-postgres-custom-manager.json
+++ b/presets/scalingo-postgres-custom-manager.json
@@ -4,7 +4,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "^scalingo.json$",
+        "(^|/)scalingo.json$",
         "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$",
         "^.circleci/config.yml$"
       ],

--- a/presets/scalingo-redis-custom-manager.json
+++ b/presets/scalingo-redis-custom-manager.json
@@ -4,7 +4,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "^scalingo.json$",
+        "(^|/)scalingo.json$",
         "(^|/)(?:docker-)?compose[^/]*\\.ya?ml$",
         "^.circleci/config.yml$"
       ],


### PR DESCRIPTION
## 🔆 Problème
Historiquement, le fichier scalingo.json se trouvait à la racine du projet Pix. Actuellement, depuis la PR permettant de ne pas déployer d'addon PG et Redis pour les fronts, celui ci se trouve dans les sous dossiers des applications et de l'API. Cependant, la configuration renovate ne cherchait qu'à la racine.

## ⛱️ Proposition
Permettre la mise à jour des fichiers scalingo.json présents dans des sous dossiers/