### PR TITLE
feat: group pix-ui update accross all frontend

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,8 +31,9 @@
     },
     {
       "matchPackageNames": [
-        "/^@1024pix\\/(?!epreuves-components$)/",
-        "/^(node|cimg/node)$/"
+        "^@1024pix/",
+        "/^(node|cimg/node)$/",
+        "!@1024pix/epreuves-components"
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["auto-bump", ":rocket: Ready to Merge"],

--- a/default.json
+++ b/default.json
@@ -37,6 +37,20 @@
       "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
       "automerge": true
+    },
+    {
+      "groupName": "pix-ui update across apps",
+      "matchPackageNames": ["@1024pix/pix-ui"],
+      "matchFileNames": [
+        "./admin/package.json",
+        "./orga/package.json",
+        "./certif/package.json",
+        "./mon/package.json-pix",
+        "./junior/package.json"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## ❄️ Problème

Actuellement renovate ouvre 1 PR pour chaque front à chaque monté de version de pix-ui.
Ce qui entraine des désynchro de version entre les front et aussi un peu de bruit.

## 🛷 Proposition

Grouper les mises à jour sur plusieurs app au sein d'un seule PR aka fusio-demande.

## ☃️ Remarques

nope

## 🧑‍🎄 Pour tester

Pas sur de savoir comment tester :D