### PR TITLE
[TECH] Supprime le label Ready To Merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   CI:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Here are the available `presets`:
   - wait 7 days after a version is published on npm to select it;
   - create at most 5 pull request per week;
   - approves its own PR using Github App Renovate Approve;
-  - adds label ":rocket: Ready to Merge" to the PR if update type is a minor or a patch;
-  - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
+  - automerge PR
 - `no-auto`:
   - runs hourly every weekday;
   - wait 7 days after a version is published on npm to select it;
@@ -28,15 +27,13 @@ Here are the available `presets`:
   - wait 7 days after a version is published on npm to select it;
   - create at most 5 pull request per week;
   - approves its own PR using Github App Renovate Approve;
-  - adds label ":rocket: Ready to Merge" to the PR if update type is a patch;
-  - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
+  - automerge PR
 - `aggressive`:
   - runs hourly every weekday;
   - wait 7 days after a version is published on npm to select it;
   - create as many pull request as necessary;
   - approves its own PR using Github App Renovate Approve;
-  - adds label ":rocket: Ready to Merge" to the PR;
-  - Jean Pierre rebases and merges the PR if required status checks are ok (ex: Actions, CircleCi, Deploy ...).
+  - approves its own PR using Github App Renovate Approve;
 
 `auto-minor` is a deprecated config and should be replaced by the `default` config.
 

--- a/aggressive.json
+++ b/aggressive.json
@@ -3,6 +3,6 @@
   "extends": ["github>1024pix/renovate-config:default"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "addLabels": ["aggressive", ":rocket: Ready to Merge"],
+  "addLabels": ["aggressive"],
   "automerge": true
 }

--- a/auto-minor.json
+++ b/auto-minor.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor"],
-      "addLabels": ["auto-minor", ":rocket: Ready to Merge"],
+      "addLabels": ["auto-minor"],
       "automerge": true
     }
   ]

--- a/auto-patch.json
+++ b/auto-patch.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
-      "addLabels": ["auto-patch", ":rocket: Ready to Merge"],
+      "addLabels": ["auto-patch"],
       "automerge": true
     }
   ]

--- a/default.json
+++ b/default.json
@@ -26,7 +26,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["lockFileMaintenance"],
-      "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
+      "addLabels": ["auto-bump"],
       "automerge": true
     },
     {
@@ -35,7 +35,7 @@
         "/^(node|cimg/node)$/"
       ],
       "matchUpdateTypes": ["minor", "patch"],
-      "addLabels": ["auto-bump", ":rocket: Ready to Merge"],
+      "addLabels": ["auto-bump"],
       "automerge": true
     }
   ]

--- a/default.json
+++ b/default.json
@@ -31,8 +31,9 @@
     },
     {
       "matchPackageNames": [
-        "/^@1024pix\\/(?!epreuves-components$)/",
-        "/^(node|cimg/node)$/"
+        "^@1024pix/",
+        "/^(node|cimg/node)$/",
+        "!@1024pix/epreuves-components"
       ],
       "matchUpdateTypes": ["minor", "patch"],
       "addLabels": ["auto-bump"],


### PR DESCRIPTION
## 🪧 Problème

Renovate ajoute le label Ready To merge mais le passage à la merge queue a supprimé le besoin d'ajouter ce label.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌈 Proposition

on supprime tous les ajouts du label Ready To Merge
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ✊ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🎉 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
